### PR TITLE
CLA0003-1183 - Remove Home Export For Passenger

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'The Clarus server cookbook, ready for the Clarus application deployment.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.7.0'
+version          '0.7.1'
 
 recipe 'cookbook_clarus', 'The Clarus server cookbook, ready for the Clarus application deployment.'
 

--- a/templates/default/sv-passenger-run.erb
+++ b/templates/default/sv-passenger-run.erb
@@ -2,8 +2,6 @@
 
 cd <%= @options[:working_directory] %>
 
-export HOME=<%= @options[:working_directory] %>
-
 exec 2>&1
 exec <%= node[:runit][:chpst_bin] %> -u <%= @options[:user] %>:<%= @options[:group] %> \
   <%= File.join('.', 'bin', 'passenger') %> start \


### PR DESCRIPTION
https://youtrack.buildempire.co.uk/issue/CLA0003-1183

It seems newer versions of Passenger want the home directory to be the home directory, as that is where passenger installs the pre-compiled binaries.

#CLA0003-1183 Fixed